### PR TITLE
Set TERM=dumb when running gdb to inhibit color codes

### DIFF
--- a/underthecovers/C/intro.ipynb
+++ b/underthecovers/C/intro.ipynb
@@ -92,7 +92,7 @@
    },
    "outputs": [],
    "source": [
-    "TermShellCmd(\"echo -e 'set disassembly-flavor intel\\nb _start\\nrun\\ndisass\\nquit' | gdb $(type -p python)\", noposttext=True, markdown=True)"
+    "TermShellCmd(\"echo -e 'set disassembly-flavor intel\\nb _start\\nrun\\ndisass\\nquit' | TERM=dumb gdb $(type -p python)\", noposttext=True, markdown=True)"
    ]
   },
   {

--- a/underthecovers/python/common.py
+++ b/underthecovers/python/common.py
@@ -995,10 +995,10 @@ def gdbCmds(gdbcmds, pretext='$ gdb', quit=True, prompt='', wait=False, nopostte
     gdbcmds = gdbcmds + '''kill
 quit'''
     #print(gdbcmds)
-    return TermShellCmd("echo '" + gdbcmds + "' | gdb -ex 'set trace-commands on' | sed 's/^(gdb) +/(gdb) /'", pretext=pretext, prompt=prompt, wait=wait, noposttext=noposttext, **kwargs)
+    return TermShellCmd("echo '" + gdbcmds + "' | TERM=dumb gdb -ex 'set trace-commands on' | sed 's/^(gdb) +/(gdb) /'", pretext=pretext, prompt=prompt, wait=wait, noposttext=noposttext, **kwargs)
 
 def gdbFile(file, pretext='$ gdb', quit=True, prompt='', wait=False, noposttext=True, **kwargs):
-    return TermShellCmd("cat " + file + " | gdb -ex 'set trace-commands on' | sed 's/^(gdb) +/(gdb) /'", pretext=pretext, prompt=prompt, wait=wait, noposttext=noposttext, **kwargs)
+    return TermShellCmd("cat " + file + " | TERM=dumb gdb -ex 'set trace-commands on' | sed 's/^(gdb) +/(gdb) /'", pretext=pretext, prompt=prompt, wait=wait, noposttext=noposttext, **kwargs)
 
 # Standard way to present answer for question and answer
 #  put question in a cell as normal markdown


### PR DESCRIPTION
GDB will, by default, emit terminal control codes to enable color
highlighting of text. This results in garbage in the output displayed in
the output of TermShellCmd().

While it is possible to disable color support in the GDB configuration
(`set style enabled off`), we can instead simply set `TERM=dumb` to disable
any terminal support for color.
